### PR TITLE
Ensure frontend scripts install dependencies automatically

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,13 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/ensure-deps.js",
     "dev": "vite",
+    "prebuild": "node scripts/ensure-deps.js",
     "build": "vite build",
+    "prelint": "node scripts/ensure-deps.js",
     "lint": "eslint .",
+    "prepreview": "node scripts/ensure-deps.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/scripts/ensure-deps.js
+++ b/frontend/scripts/ensure-deps.js
@@ -1,0 +1,16 @@
+import { existsSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const projectRoot = dirname(__dirname)
+const vitePackageJson = join(projectRoot, 'node_modules', 'vite', 'package.json')
+
+if (!existsSync(vitePackageJson)) {
+  console.log('Installing frontend dependencies...')
+  execSync('npm install', { cwd: projectRoot, stdio: 'inherit' })
+} else {
+  console.log('Frontend dependencies already installed.')
+}


### PR DESCRIPTION
## Summary
- add a small helper that installs the frontend npm dependencies when Vite is missing
- wire the helper into the dev/build/lint/preview lifecycles so npm scripts can run without manual setup

## Testing
- npm run build
- npm run lint *(fails: existing lint violations in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c84cdfd928832da74474360ffcdf80