### PR TITLE
Configure backend CORS and frontend API base URLs

### DIFF
--- a/frontend/src/AuthenticatePages/LoginForm.jsx
+++ b/frontend/src/AuthenticatePages/LoginForm.jsx
@@ -2,6 +2,7 @@ import { useState, useContext, useEffect } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
 import { AuthContext } from "../context/AuthContext";
+import { resolveApiUrl } from "../config/api";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
@@ -33,7 +34,7 @@ export default function LoginForm() {
     setErrorMsg("");
 
     try {
-      const res = await axios.post("http://localhost:8000/api/auth/login", {
+      const res = await axios.post(resolveApiUrl("/auth/login"), {
         email,
         password,
       });

--- a/frontend/src/AuthenticatePages/SignUpForm.jsx
+++ b/frontend/src/AuthenticatePages/SignUpForm.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import axios from "axios";
+import { resolveApiUrl } from "../config/api";
 
 export default function SignUpForm() {
   const navigate = useNavigate();
@@ -121,7 +122,7 @@ export default function SignUpForm() {
     }
 
     try {
-      const response = await axios.post("http://localhost:8000/api/auth/register", formData);
+      const response = await axios.post(resolveApiUrl("/auth/register"), formData);
       
       // With the new system, successful registration always redirects to verify page
       // since user must verify email before account creation

--- a/frontend/src/Pages/Admin/AdminHome.jsx
+++ b/frontend/src/Pages/Admin/AdminHome.jsx
@@ -7,6 +7,7 @@ import AdminRecentSubmission from "../../components/Admin/AdminRecentSubmissions
 import SubmissionTrendsChart from "../../components/Admin/SubmissionTrends";
 import StatusDistributionChart from "../../components/Admin/StatusDistributionChart";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 const AdminHome = () => {
   const [stats, setStats] = useState([
@@ -38,7 +39,6 @@ const AdminHome = () => {
   // 🆕 reviewer workload state
   const [reviewers, setReviewers] = useState([]);
 
-  const BASE_URL = "http://localhost:8000/api";
   const token = localStorage.getItem("token");
   const headers = { Authorization: `Bearer ${token}` };
 
@@ -52,7 +52,7 @@ const AdminHome = () => {
       setLoading(true);
       setError(null);
 
-      const response = await axios.get(`${BASE_URL}/admin/stats`, {
+      const response = await axios.get(resolveApiUrl("/admin/stats"), {
         headers,
         withCredentials: true,
       });
@@ -101,7 +101,7 @@ const AdminHome = () => {
   // 🆕 fetch reviewer workload
   const fetchReviewerWorkload = async () => {
     try {
-      const response = await axios.get(`${BASE_URL}/admin/reviewer-workload`, {
+      const response = await axios.get(resolveApiUrl("/admin/reviewer-workload"), {
         headers,
         withCredentials: true,
       });

--- a/frontend/src/Pages/Admin/AdminPapers.jsx
+++ b/frontend/src/Pages/Admin/AdminPapers.jsx
@@ -4,8 +4,7 @@ import CommonSubmissionTable from "../../components/Common/CommonSubmissionTable
 import FilterBar from "../../components/Common/FilterBar";
 import axios from "axios";
 import PdfViewerModal from "../../components/Common/PdfViewerModal";
-
-const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
+import { resolveApiUrl } from "../../config/api";
 
 function AdminPapers() {
   const [filters, setFilters] = useState({
@@ -28,7 +27,7 @@ function AdminPapers() {
   useEffect(() => {
     const fetchPapers = async () => {
       try {
-        const { data } = await axios.get(`${API_BASE_URL}/admin/papers`, {
+        const { data } = await axios.get(resolveApiUrl("/admin/papers"), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
         setSubmissions(data?.papers || []);
@@ -46,7 +45,7 @@ function AdminPapers() {
   useEffect(() => {
     const fetchDepartments = async () => {
       try {
-        const { data } = await axios.get(`${API_BASE_URL}/admin/departments`, {
+        const { data } = await axios.get(resolveApiUrl("/admin/departments"), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
         // Expecting data like: { success: true, departments: [{department_id, department_name}] }

--- a/frontend/src/Pages/Admin/AdminProposal.jsx
+++ b/frontend/src/Pages/Admin/AdminProposal.jsx
@@ -5,8 +5,7 @@ import CommonSubmissionTable from "../../components/Common/CommonSubmissionTable
 import FilterBar from "../../components/Common/FilterBar";
 import axios from "axios";
 import PdfViewerModal from "../../components/Common/PdfViewerModal";
-
-const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
+import { resolveApiUrl } from "../../config/api";
 
 function AdminProposals() {
   const [filters, setFilters] = useState({
@@ -29,7 +28,7 @@ function AdminProposals() {
   useEffect(() => {
     const fetchProposals = async () => {
       try {
-        const { data } = await axios.get(`${API_BASE_URL}/admin/proposals`, {
+        const { data } = await axios.get(resolveApiUrl("/admin/proposals"), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
         setSubmissions(data?.proposals || []);
@@ -47,7 +46,7 @@ function AdminProposals() {
   useEffect(() => {
     const fetchDepartments = async () => {
       try {
-        const { data } = await axios.get(`${API_BASE_URL}/admin/departments`, {
+        const { data } = await axios.get(resolveApiUrl("/admin/departments"), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
         const opts = (data?.departments || [])

--- a/frontend/src/Pages/Admin/AdminTeamDetails.jsx
+++ b/frontend/src/Pages/Admin/AdminTeamDetails.jsx
@@ -5,6 +5,7 @@ import TeamDescriptionCard from "../../components/Admin/TeamDescriptionCard";
 import TeamMembersCard from "../../components/Admin/TeamMembersCard";
 import TeamPapersCard from "../../components/Admin/TeamsPapersCard";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 const AdminTeamDetails = () => {
   const { id } = useParams();
@@ -14,7 +15,6 @@ const AdminTeamDetails = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const BASE_URL = "http://localhost:8000/api";
   const token = localStorage.getItem("token");
   const headers = { Authorization: `Bearer ${token}` };
 
@@ -27,7 +27,7 @@ const AdminTeamDetails = () => {
       setLoading(true);
       setError(null);
       
-      const response = await axios.get(`${BASE_URL}/admin/teams/${id}`, {
+      const response = await axios.get(resolveApiUrl(`/admin/teams/${id}`), {
         headers,
         withCredentials: true
       });

--- a/frontend/src/Pages/Admin/ReviewCommittee.jsx
+++ b/frontend/src/Pages/Admin/ReviewCommittee.jsx
@@ -5,6 +5,7 @@ import { Users, CheckCircle, Clock, UserPlus } from "lucide-react";
 import CommonButton from "../../components/Common/CommonButton";
 import AddReviewerModal from "../../components/Admin/AddReviewerModal";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 const ReviewerCommittee = () => {
   const [showModal, setShowModal] = useState(false);
@@ -20,7 +21,6 @@ const ReviewerCommittee = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
-  const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
   const authHeaders = { Authorization: `Bearer ${localStorage.getItem("token")}` };
 
   useEffect(() => {
@@ -35,7 +35,7 @@ const ReviewerCommittee = () => {
 
   const fetchReviewers = async () => {
     try {
-      const { data } = await axios.get(`${API_BASE_URL}/reviewers`, { headers: authHeaders });
+      const { data } = await axios.get(resolveApiUrl("/reviewers"), { headers: authHeaders });
       if (data?.reviewers) setReviewers(data.reviewers);
       if (data?.stats) setStats(data.stats);
     } catch (err) {
@@ -46,7 +46,7 @@ const ReviewerCommittee = () => {
 
   const fetchPotentialReviewers = async () => {
     try {
-      const { data } = await axios.get(`${API_BASE_URL}/reviewers/potential`, { headers: authHeaders });
+      const { data } = await axios.get(resolveApiUrl("/reviewers/potential"), { headers: authHeaders });
       setPotentialReviewers(data || []);
     } catch (err) {
       console.error("Error fetching potential reviewers:", err);
@@ -60,7 +60,7 @@ const ReviewerCommittee = () => {
     try {
       setError("");
       const payload = { reviewer_ids: selectedTeacherIds, custom_message: customMessage };
-      await axios.post(`${API_BASE_URL}/reviewers/invite`, payload, {
+      await axios.post(resolveApiUrl("/reviewers/invite"), payload, {
         headers: { ...authHeaders, "Content-Type": "application/json" },
       });
       alert(`Invitations sent to ${selectedTeacherIds.length} teacher(s).`);
@@ -83,7 +83,7 @@ const ReviewerCommittee = () => {
   const handleSendMail = async (teacherId) => {
     try {
       await axios.post(
-        `${API_BASE_URL}/reviewers/invite`,
+        resolveApiUrl("/reviewers/invite"),
         { reviewer_ids: [teacherId] },
         { headers: authHeaders }
       );
@@ -97,7 +97,7 @@ const ReviewerCommittee = () => {
   const handleUpdateReviewerStatus = async (reviewerId, status) => {
     try {
       await axios.put(
-        `${API_BASE_URL}/reviewers/${reviewerId}`,
+        resolveApiUrl(`/reviewers/${reviewerId}`),
         { status },
         { headers: { ...authHeaders, "Content-Type": "application/json" } }
       );
@@ -111,7 +111,7 @@ const ReviewerCommittee = () => {
   const handleDeleteReviewer = async (reviewerId) => {
     if (!window.confirm("Are you sure you want to delete this reviewer?")) return;
     try {
-      await axios.delete(`${API_BASE_URL}/reviewers/${reviewerId}`, { headers: authHeaders });
+      await axios.delete(resolveApiUrl(`/reviewers/${reviewerId}`), { headers: authHeaders });
       alert("Reviewer deleted successfully!");
       fetchReviewers();
     } catch (err) {

--- a/frontend/src/Pages/Admin/Teams.jsx
+++ b/frontend/src/Pages/Admin/Teams.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { FaUsers, FaFileAlt, FaFileInvoice, FaStickyNote } from "react-icons/fa";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 const getInitials = (name) => name
   .split(" ")
@@ -120,7 +121,6 @@ const TeamsPage = () => {
   const [error, setError] = useState(null);
   const [showCount, setShowCount] = useState(6);
 
-  const BASE_URL = "http://localhost:8000/api";
   const token = localStorage.getItem("token");
   const headers = { Authorization: `Bearer ${token}` };
 
@@ -133,7 +133,7 @@ const TeamsPage = () => {
       setLoading(true);
       setError(null);
       
-      const response = await axios.get(`${BASE_URL}/admin/teams`, {
+      const response = await axios.get(resolveApiUrl("/admin/teams"), {
         headers,
         withCredentials: true
       });

--- a/frontend/src/Pages/Admin/WaitingAssignment.jsx
+++ b/frontend/src/Pages/Admin/WaitingAssignment.jsx
@@ -11,6 +11,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { AuthContext } from "../../context/AuthContext";
+import { BACKEND_ORIGIN, resolveApiUrl } from "../../config/api";
 
 const WaitingAssignment = () => {
   const [showModal, setShowModal] = useState(false);
@@ -35,10 +36,9 @@ const WaitingAssignment = () => {
   const fetchWaitingAssignments = async () => {
     setLoading(true);
     try {
-      const res = await axios.get(
-        "http://localhost:8000/api/assignments/waiting",
-        { headers: getAuthHeaders() }
-      );
+      const res = await axios.get(resolveApiUrl("/assignments/waiting"), {
+        headers: getAuthHeaders(),
+      });
 
       if (res.data) {
         const { waitingItems = [], stats: responseStats = {} } = res.data;
@@ -67,7 +67,9 @@ const WaitingAssignment = () => {
         else if (status === 404) setError("API endpoint not found. Please check server configuration.");
         else setError(`Server error (${status}): ${message}`);
       } else if (err.request) {
-        setError("Cannot connect to server. Please ensure the backend is running on http://localhost:8000");
+        setError(
+          `Cannot connect to server. Please ensure the backend is running on ${BACKEND_ORIGIN}`
+        );
       } else {
         setError(`Request failed: ${err.message}`);
       }
@@ -86,10 +88,10 @@ const WaitingAssignment = () => {
       if (itemType) params.item_type = itemType;
       if (itemId) params.item_id = itemId;
 
-      const res = await axios.get(
-        "http://localhost:8000/api/assignments/reviewers",
-        { headers: getAuthHeaders(), params }
-      );
+      const res = await axios.get(resolveApiUrl("/assignments/reviewers"), {
+        headers: getAuthHeaders(),
+        params,
+      });
 
       if (Array.isArray(res.data)) {
         setPotentialReviewers(res.data);
@@ -131,11 +133,9 @@ const WaitingAssignment = () => {
         ],
       };
 
-      const res = await axios.post(
-        "http://localhost:8000/api/assignments/assign",
-        payload,
-        { headers: getAuthHeaders() }
-      );
+      const res = await axios.post(resolveApiUrl("/assignments/assign"), payload, {
+        headers: getAuthHeaders(),
+      });
 
       const { success, results, message } = res.data || {};
       if (success) {
@@ -173,11 +173,9 @@ const WaitingAssignment = () => {
         item_type: paper.type === "paper" ? "paper" : "proposal",
       };
 
-      const res = await axios.post(
-        "http://localhost:8000/api/assignments/auto-match",
-        payload,
-        { headers: getAuthHeaders() }
-      );
+      const res = await axios.post(resolveApiUrl("/assignments/auto-match"), payload, {
+        headers: getAuthHeaders(),
+      });
 
       if (res.data) {
         if (res.data.recommendations) {

--- a/frontend/src/Pages/Preference/PreferencePage.jsx
+++ b/frontend/src/Pages/Preference/PreferencePage.jsx
@@ -2,6 +2,7 @@ import { useContext, useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { AuthContext } from "../../context/AuthContext";
+import { resolveApiUrl } from "../../config/api";
 import AdditionalPreferences from "../../components/Preference/AdditionalPreferences";
 import Department from "../../components/Preference/Department";
 import ResearchFields from "../../components/Preference/ResearchFields";
@@ -33,7 +34,7 @@ function PreferencePage() {
   const fetchProfileData = async () => {
     try {
       const { data } = await axios.get(
-        `http://localhost:8000/api/user/profile/${resolvedUserId}`,
+        resolveApiUrl(`/user/profile/${resolvedUserId}`),
         authHeaders
       );
       if (data.success) setProfileData(data.profile);
@@ -47,9 +48,11 @@ function PreferencePage() {
     try {
       setPreferencesLoading(true);
       const [deptRes, domainsRes, prefsRes] = await Promise.all([
-        axios.get("http://localhost:8000/api/departments", authHeaders),
-        axios.get("http://localhost:8000/api/domains", authHeaders),
-        axios.get(`http://localhost:8000/api/user/preferences/${resolvedUserId}`, authHeaders).catch(() => ({ data: { preferences: {} } })),
+        axios.get(resolveApiUrl("/departments"), authHeaders),
+        axios.get(resolveApiUrl("/domains"), authHeaders),
+        axios
+          .get(resolveApiUrl(`/user/preferences/${resolvedUserId}`), authHeaders)
+          .catch(() => ({ data: { preferences: {} } })),
       ]);
 
       setDepartments(deptRes.data.departments || []);
@@ -97,7 +100,7 @@ function PreferencePage() {
     if (!departmentId) { setAvailableDomains(allDomains); return; }
     try {
       const res = await axios.get(
-        `http://localhost:8000/api/department/${departmentId}/domains`,
+        resolveApiUrl(`/department/${departmentId}/domains`),
         authHeaders
       );
       setAvailableDomains(res.data.domains || []);
@@ -149,7 +152,7 @@ function PreferencePage() {
       console.log("Saving preferences (full payload):", payload);
 
       const { data } = await axios.put(
-        `http://localhost:8000/api/user/preferences/${resolvedUserId}`,
+        resolveApiUrl(`/user/preferences/${resolvedUserId}`),
         payload,
         { headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" } }
       );

--- a/frontend/src/Pages/Profile/ProfilePage.jsx
+++ b/frontend/src/Pages/Profile/ProfilePage.jsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState, useMemo } from "react";
 import axios from "axios";
 import { AuthContext } from "../../context/AuthContext";
+import { resolveApiUrl } from "../../config/api";
 import EditButton from "../../components/Profile/EditButton";
 import PersonalInfo from "../../components/Profile/PersonalInfo";
 import ProfileHeader from "../../components/Profile/ProfileHeader";
@@ -25,7 +26,7 @@ const ProfilePage = () => {
       // Add cache busting to the profile request
       const timestamp = Date.now();
       const response = await axios.get(
-        `http://localhost:8000/api/user/profile/${resolvedUserId}?t=${timestamp}`,
+        resolveApiUrl(`/user/profile/${resolvedUserId}?t=${timestamp}`),
         {
           headers: {
             Authorization: `Bearer ${token}`,

--- a/frontend/src/Pages/Reviewer/AssignedPapersPage.jsx
+++ b/frontend/src/Pages/Reviewer/AssignedPapersPage.jsx
@@ -6,9 +6,7 @@ import CommonSubmissionTable from "../../components/Common/CommonSubmissionTable
 import FilterBar from "../../components/Common/FilterBar";
 import CommonButton from "../../components/Common/CommonButton";
 import axios from "axios";
-
-const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 function formatDate(iso) {
   if (!iso) return "-";
@@ -79,7 +77,7 @@ export default function AssignedPapersPage() {
       if (status) params.append("status", status);
 
       const { data } = await axios.get(
-        `${API_BASE_URL}/reviewer/assigned-papers?${params.toString()}`,
+        resolveApiUrl(`/reviewer/assigned-papers?${params.toString()}`),
         {
           headers: getAuthHeaders(),
         }
@@ -120,7 +118,7 @@ export default function AssignedPapersPage() {
       )
         return;
       await axios.patch(
-        `${API_BASE_URL}/reviewer/assignments/${assignmentId}/status`,
+        resolveApiUrl(`/reviewer/assignments/${assignmentId}/status`),
         { status },
         { headers: getAuthHeaders() }
       );
@@ -137,9 +135,7 @@ export default function AssignedPapersPage() {
     console.log("Opening PDF with URL:", pdf_path);
     if (pdf_path) {
       // Use the same URL construction logic as PaperCard
-      const fullPdfUrl = pdf_path?.startsWith("http")
-        ? pdf_path
-        : `${API_BASE}${pdf_path?.startsWith("/") ? pdf_path : "/" + pdf_path}`;
+      const fullPdfUrl = resolveBackendUrl(pdf_path);
 
       setPdfUrl(fullPdfUrl);
       setTitle(paperTitle || "PDF Document");

--- a/frontend/src/Pages/Reviewer/AssignedProposalsPage.jsx
+++ b/frontend/src/Pages/Reviewer/AssignedProposalsPage.jsx
@@ -6,9 +6,7 @@ import CommonSubmissionTable from "../../components/Common/CommonSubmissionTable
 import FilterBar from "../../components/Common/FilterBar";
 import CommonButton from "../../components/Common/CommonButton";
 import axios from "axios";
-
-const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 function formatDate(iso) {
   if (!iso) return "-";
@@ -72,7 +70,7 @@ export default function AssignedProposalsPage() {
       if (status) params.append("status", status);
 
       const { data } = await axios.get(
-        `${API_BASE_URL}/reviewer/assigned-proposals?${params.toString()}`,
+        resolveApiUrl(`/reviewer/assigned-proposals?${params.toString()}`),
         {
           headers: getAuthHeaders(),
         }
@@ -108,7 +106,7 @@ export default function AssignedProposalsPage() {
       )
         return;
       await axios.patch(
-        `${API_BASE_URL}/reviewer/assignments/${assignmentId}/status`,
+        resolveApiUrl(`/reviewer/assignments/${assignmentId}/status`),
         { status },
         { headers: getAuthHeaders() }
       );
@@ -233,14 +231,8 @@ export default function AssignedProposalsPage() {
           <div className="flex">
             <button
               onClick={() => {
-                const fullPdfUrl = row.pdf_path?.startsWith("http")
-                  ? row.pdf_path
-                  : row.pdf_path
-                  ? `${API_BASE}${
-                      row.pdf_path?.startsWith("/")
-                        ? row.pdf_path
-                        : "/" + row.pdf_path
-                    }`
+                const fullPdfUrl = row.pdf_path
+                  ? resolveBackendUrl(row.pdf_path)
                   : `/public/documents/${row.proposalId || row.id}`;
                 window.open(fullPdfUrl, "_blank");
               }}

--- a/frontend/src/Pages/Reviewer/PaperReviewPage.jsx
+++ b/frontend/src/Pages/Reviewer/PaperReviewPage.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 import {
   ArrowLeft,
   Download,
@@ -16,9 +17,6 @@ import {
   AlertCircle,
   XCircle,
 } from "lucide-react";
-
-const API_BASE_URL =
-  import.meta.env.VITE_API_URL || "http://localhost:8000/api";
 
 const USE_CODE_ENDPOINT = true;
 
@@ -69,13 +67,11 @@ const PaperReviewPage = () => {
 
   const buildEndpoint = (suffix = "") => {
     if (USE_CODE_ENDPOINT) {
-      return `${API_BASE_URL}/reviewer/review/${normalizedCode}${suffix}`;
+      return resolveApiUrl(`/reviewer/review/${normalizedCode}${suffix}`);
     }
-    // fallback style (not recommended with your current backend)
-    // fallback style (not recommended)
-    return `${API_BASE_URL}/reviewer/${
-      isProposalPath ? "proposal" : "paper"
-    }/${paperId}${suffix}`;
+    return resolveApiUrl(
+      `/reviewer/${isProposalPath ? "proposal" : "paper"}/${paperId}${suffix}`
+    );
   };
 
   const authHeader = useMemo(

--- a/frontend/src/Pages/Reviewer/ReviewHistoryPage.jsx
+++ b/frontend/src/Pages/Reviewer/ReviewHistoryPage.jsx
@@ -7,9 +7,7 @@ import ReviewTable from "../../components/Common/ReviewTable";
 import PdfViewerModal from "../../components/Common/PdfViewerModal"; 
 import { FaCheckCircle, FaClock, FaUpload, FaClipboard } from "react-icons/fa";
 import axios from "axios";
-
-const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const ReviewHistoryPage = () => {
   const [filters, setFilters] = useState({
@@ -58,7 +56,7 @@ const ReviewHistoryPage = () => {
         });
 
         const { data } = await axios.get(
-          `${API_BASE_URL}/reviewer/review-history?${queryParams.toString()}`,
+          resolveApiUrl(`/reviewer/review-history?${queryParams.toString()}`),
           { headers: { Authorization: `Bearer ${localStorage.getItem("token")}` } }
         );
 
@@ -89,7 +87,7 @@ const ReviewHistoryPage = () => {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const { data } = await axios.get(`${API_BASE_URL}/reviewer/stats/me`, {
+        const { data } = await axios.get(resolveApiUrl("/reviewer/stats/me"), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
 
@@ -114,10 +112,8 @@ const ReviewHistoryPage = () => {
   };
 
   const handleViewPdf = (row) => {
-    const fullPdfUrl = row.pdf_path?.startsWith("http")
-      ? row.pdf_path
-      : row.pdf_path
-      ? `${API_BASE}${row.pdf_path?.startsWith("/") ? row.pdf_path : "/" + row.pdf_path}`
+    const fullPdfUrl = row.pdf_path
+      ? resolveBackendUrl(row.pdf_path)
       : `/public/documents/${row.proposalId || row.id}`;
 
     setPdfUrl(fullPdfUrl); 

--- a/frontend/src/Pages/Reviewer/ReviewerDashboard.jsx
+++ b/frontend/src/Pages/Reviewer/ReviewerDashboard.jsx
@@ -1,6 +1,7 @@
 // Pages/ReviewerDashboard.jsx
 import { useEffect, useMemo, useState } from "react";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 import {
   FaClipboard,
   FaCheckCircle,
@@ -10,8 +11,7 @@ import {
 import AssignedPapersTable from "../../components/Reviewer/AssignedPapersTable";
 import StatCard from "../../components/Common/StatCard";
 
-const API_BASE_URL =
-  import.meta.env.VITE_API_URL || "http://localhost:8000/api";
+const API_BASE_URL = resolveApiUrl();
 
 export default function ReviewerDashboard() {
   const [stats, setStats] = useState({

--- a/frontend/src/Pages/Reviewer/ReviewerLayout.jsx
+++ b/frontend/src/Pages/Reviewer/ReviewerLayout.jsx
@@ -13,6 +13,7 @@ import Topbar from "../../components/Common/Topbar";
 import Sidebar from "../../components/Common/Sidebar";
 import LogoutModal from "../../components/Common/LogoutModal";
 import { AuthContext } from "./../../context/AuthContext";
+import { resolveApiUrl } from "../../config/api";
 // import AssignedPapersTable from "../../components/Reviewer/AssignedPapersTable";
 
 const ReviewerLayout = () => {
@@ -47,9 +48,7 @@ const ReviewerLayout = () => {
         navigate("/login");
         return;
       }
-      const backendBaseUrl =
-        import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
-      const response = await fetch(`${backendBaseUrl}/api/auth/switch-role`, {
+      const response = await fetch(resolveApiUrl("/auth/switch-role"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/Pages/Student/MyTeams.jsx
+++ b/frontend/src/Pages/Student/MyTeams.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 import {
   FaClipboard,
   FaCheckCircle,
@@ -29,7 +30,7 @@ const MyTeams = () => {
       try {
         setLoading(true);
         setError(null);
-        const response = await axios.get("http://localhost:8000/api/student/my-teams", {
+        const response = await axios.get(resolveApiUrl("/student/my-teams"), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
         console.log("Teams fetched:", response.data.data);

--- a/frontend/src/Pages/Student/StudentDashboard.jsx
+++ b/frontend/src/Pages/Student/StudentDashboard.jsx
@@ -8,8 +8,9 @@ import {
 import StatCard from "../../components/Common/StatCard";
 import RecentSubmission from "../../components/Common/RecentSubmission";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000/api";
+const API_BASE = resolveApiUrl();
 
 const StudentDashboard = () => {
   const [loading, setLoading] = useState(true);

--- a/frontend/src/Pages/Student/StudentMyPapers.jsx
+++ b/frontend/src/Pages/Student/StudentMyPapers.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import PaperCard from "../../components/Common/PaperCard";
 import FilterBar from "../../components/Common/FilterBar";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const StudentMyPapers = () => {
   // filters
@@ -68,7 +69,7 @@ const StudentMyPapers = () => {
         setError(null);
 
         const res = await axios.get(
-          "http://localhost:8000/api/student/my-teams/papers",
+          resolveApiUrl("/student/my-teams/papers"),
           {
             headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
             withCredentials: true,
@@ -91,7 +92,7 @@ const StudentMyPapers = () => {
           aggregatedDecision: (p.aggregated_decision || "").toUpperCase(), // ACCEPT | REJECT | MINOR_REVISIONS | MAJOR_REVISIONS | ""
           reviewers: [],
           comments: 0,
-          fileUrl: p.download_url || null,
+          fileUrl: p.download_url ? resolveBackendUrl(p.download_url) : null,
           domainName: p.team?.domain?.domain_name || null,
         }));
 

--- a/frontend/src/Pages/Student/StudentMyProposals.jsx
+++ b/frontend/src/Pages/Student/StudentMyProposals.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect } from "react";
 import PaperCard from "../../components/Common/PaperCard";
 import FilterBar from "../../components/Common/FilterBar";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const StudentMyProposals = () => {
   // filters
@@ -81,7 +82,7 @@ const StudentMyProposals = () => {
         setError(null);
 
         const res = await axios.get(
-          "http://localhost:8000/api/student/my-teams/proposals",
+          resolveApiUrl("/student/my-teams/proposals"),
           {
             headers: {
               Authorization: `Bearer ${localStorage.getItem("token")}`,
@@ -109,7 +110,7 @@ const StudentMyProposals = () => {
             role: "Contributor",
             reviewers: [],
             comments: 0,
-            fileUrl: p.download_url,
+            fileUrl: p.download_url ? resolveBackendUrl(p.download_url) : null,
           };
         });
 

--- a/frontend/src/Pages/Student/StudentTeamDetails.jsx
+++ b/frontend/src/Pages/Student/StudentTeamDetails.jsx
@@ -6,6 +6,7 @@ import DocumentList from "../../components/Teacher/TeamManagement/DocumentList";
 import Comments from "../../components/Teacher/TeamManagement/Comment";
 import TeamCard from "../../components/Common/TeamCard";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const StudentTeamDetails = () => {
   const { id } = useParams();
@@ -22,7 +23,7 @@ const StudentTeamDetails = () => {
       try {
         setLoading(true);
         setError(null);
-        const res = await axios.get(`http://localhost:8000/api/student/teams/${id}`, {
+        const res = await axios.get(resolveApiUrl(`/student/teams/${id}`), {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         });
         setTeam(res.data.data);
@@ -43,8 +44,8 @@ const StudentTeamDetails = () => {
         const headers = { Authorization: `Bearer ${token}` };
 
         const [proposalsRes, papersRes] = await Promise.all([
-          axios.get(`http://localhost:8000/api/teams/${id}/proposals`, { headers }),
-          axios.get(`http://localhost:8000/api/teams/${id}/papers`, { headers }),
+          axios.get(resolveApiUrl(`/teams/${id}/proposals`), { headers }),
+          axios.get(resolveApiUrl(`/teams/${id}/papers`), { headers }),
         ]);
 
         const docs = [
@@ -55,7 +56,7 @@ const StudentTeamDetails = () => {
             createdAtRaw: p.created_at,
             uploadedAt: new Date(p.created_at).toLocaleDateString("en-GB"),
             sizeBytes: p.file_size || 0,
-            href: p.pdf_path,
+            href: resolveBackendUrl(p.pdf_path),
             status: p.status,
           })),
           ...papersRes.data.data.map((p) => ({
@@ -65,7 +66,7 @@ const StudentTeamDetails = () => {
             createdAtRaw: p.created_at,
             uploadedAt: new Date(p.created_at).toLocaleDateString("en-GB"),
             sizeBytes: p.file_size || 0,
-            href: p.pdf_path,
+            href: resolveBackendUrl(p.pdf_path),
             status: p.status,
           })),
         ];

--- a/frontend/src/Pages/Teacher/CreateTeam.jsx
+++ b/frontend/src/Pages/Teacher/CreateTeam.jsx
@@ -3,6 +3,7 @@ import React, { useState, useContext, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { FaArrowLeft } from "react-icons/fa";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 import BasicInfoForm from "../../components/Teacher/CreateTeam/BasicInfoForm";
 import MemberManager from "../../components/Teacher/CreateTeam/MemberManager";
@@ -46,7 +47,7 @@ const CreateTeam = () => {
     if (!token) return;
 
     axios
-      .get("http://localhost:8000/api/me/context", {
+      .get(resolveApiUrl("/me/context"), {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then((res) => {
@@ -132,7 +133,7 @@ const CreateTeam = () => {
       }
       console.log("Final payload to backend:", [...formData.entries()]);
       const token = localStorage.getItem("token");
-      await axios.post("http://localhost:8000/api/teams", formData, {
+      await axios.post(resolveApiUrl("/teams"), formData, {
         headers: {
           "Content-Type": "multipart/form-data",
           Authorization: `Bearer ${token}`,

--- a/frontend/src/Pages/Teacher/MyPapers.jsx
+++ b/frontend/src/Pages/Teacher/MyPapers.jsx
@@ -3,6 +3,7 @@ import PaperCard from "../../components/Common/PaperCard";
 import UploadDocModal from "../../components/Teacher/CreateTeam/UploadModal";
 import FilterBar from "../../components/Common/FilterBar";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const MyPapers = () => {
   // filters
@@ -86,7 +87,7 @@ const MyPapers = () => {
         setError(null);
 
         const res = await axios.get(
-          "http://localhost:8000/api/teacher/my-teams/papers",
+          resolveApiUrl("/teacher/my-teams/papers"),
           {
             headers: {
               Authorization: `Bearer ${localStorage.getItem("token")}`,
@@ -117,7 +118,7 @@ const MyPapers = () => {
             role: "Contributor",
             reviewers: [],
             comments: 0,
-            fileUrl: p.download_url,
+            fileUrl: p.download_url ? resolveBackendUrl(p.download_url) : null,
           };
         });
 

--- a/frontend/src/Pages/Teacher/MyProposals.jsx
+++ b/frontend/src/Pages/Teacher/MyProposals.jsx
@@ -3,6 +3,7 @@ import PaperCard from "../../components/Common/PaperCard";
 import UploadDocModal from "../../components/Teacher/CreateTeam/UploadModal";
 import FilterBar from "../../components/Common/FilterBar";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const MyProposals = () => {
   // filters
@@ -88,7 +89,7 @@ const MyProposals = () => {
         setError(null);
 
         const res = await axios.get(
-          "http://localhost:8000/api/teacher/my-teams/proposals",
+          resolveApiUrl("/teacher/my-teams/proposals"),
           {
             headers: {
               Authorization: `Bearer ${localStorage.getItem("token")}`,
@@ -119,7 +120,7 @@ const MyProposals = () => {
             role: "Contributor",
             reviewers: [],
             comments: 0,
-            fileUrl: p.download_url,
+            fileUrl: p.download_url ? resolveBackendUrl(p.download_url) : null,
           };
         });
 

--- a/frontend/src/Pages/Teacher/SubmissionHistory.jsx
+++ b/frontend/src/Pages/Teacher/SubmissionHistory.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import FilterBar from "../../components/Common/FilterBar";
 import SubmissionTable from "../../components/Teacher/SubmissionTable";
-
-const API_BASE = "http://localhost:8000"; 
+import { resolveApiUrl } from "../../config/api";
 
 const parseSearchCode = (raw) => {
   if (!raw) return null;
@@ -27,7 +26,7 @@ export default function SubmissionHistory() {
   useEffect(() => {
     const fetchFilters = async () => {
       try {
-        const res = await axios.get(`${API_BASE}/api/submissions/filters`, {
+        const res = await axios.get(resolveApiUrl("/submissions/filters"), {
           headers: {
             Authorization: `Bearer ${localStorage.getItem("token")}`,
           },
@@ -127,7 +126,7 @@ export default function SubmissionHistory() {
         params.append("sort", sort.key);
         params.append("order", sort.dir);
 
-        const url = `${API_BASE}/api/submissions?${params.toString()}`;
+        const url = resolveApiUrl(`/submissions?${params.toString()}`);
 
         const res = await axios.get(url, {
           headers: {

--- a/frontend/src/Pages/Teacher/TeacherDashboard.jsx
+++ b/frontend/src/Pages/Teacher/TeacherDashboard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 import {
   FaClipboard,
   FaCheckCircle,
@@ -10,7 +11,7 @@ import StatCard from "../../components/Common/StatCard"; // <-- capital S
 import TeamActivity from "../../components/Common/TeamActivity";
 import RecentSubmission from "../../components/Common/RecentSubmission";
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8000/api";
+const API_BASE_URL = resolveApiUrl();
 
 /** Normalize status strings coming from DB/enums */
 const norm = (s) => (typeof s === "string" ? s.trim().toUpperCase() : "");

--- a/frontend/src/Pages/Teacher/TeacherLayout.jsx
+++ b/frontend/src/Pages/Teacher/TeacherLayout.jsx
@@ -4,6 +4,7 @@ import Sidebar from "../../components/Common/Sidebar";
 import Topbar from "../../components/Common/Topbar";
 import LogoutModal from "../../components/Common/LogoutModal";
 import { AuthContext } from "../../context/AuthContext";
+import { resolveApiUrl } from "../../config/api";
 import {
   FaFileAlt,
   FaUsers,
@@ -40,8 +41,7 @@ const TeacherLayout = () => {
   const switchToReviewer = async () => {
     try {
       const token = localStorage.getItem("token");
-      const backendBaseUrl = "http://localhost:8000";
-      const response = await fetch(`${backendBaseUrl}/api/auth/switch-role`, {
+      const response = await fetch(resolveApiUrl("/auth/switch-role"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/Pages/Teacher/TeamDetails.jsx
+++ b/frontend/src/Pages/Teacher/TeamDetails.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 import { FaArrowLeft, FaEdit, FaCog } from "react-icons/fa";
 import MemberList from "../../components/Common/MemberList";
 import PendingApplications from "../../components/Teacher/TeamManagement/PendingApplication";
@@ -35,7 +36,7 @@ const TeamDetails = () => {
     try {
       setLoading(true);
       const response = await axios.get(
-        `http://localhost:8000/api/teacher/teams/${Number(id)}`,
+        resolveApiUrl(`/teacher/teams/${Number(id)}`),
         {
           headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
         }
@@ -57,10 +58,10 @@ const TeamDetails = () => {
       const headers = { Authorization: `Bearer ${token}` };
 
       const [proposalsRes, papersRes] = await Promise.all([
-        axios.get(`http://localhost:8000/api/teams/${id}/proposals`, {
+        axios.get(resolveApiUrl(`/teams/${id}/proposals`), {
           headers,
         }),
-        axios.get(`http://localhost:8000/api/teams/${id}/papers`, { headers }),
+        axios.get(resolveApiUrl(`/teams/${id}/papers`), { headers }),
       ]);
 
       const allDocs = [
@@ -72,7 +73,7 @@ const TeamDetails = () => {
           uploadedAt: new Date(p.created_at).toLocaleDateString(),
           uploadedBy: p.teacher?.user?.name || "Unknown",
           sizeBytes: p.file_size,
-          href: p.pdf_path,
+          href: resolveBackendUrl(p.pdf_path),
           status: p.status,
           abstract: p.abstract,
           // domain: p.team?.domain?.domain_name, // if you included team.domain in API
@@ -85,7 +86,7 @@ const TeamDetails = () => {
           uploadedAt: new Date(p.created_at).toLocaleDateString(),
           uploadedBy: p.teacher?.user?.name || "Unknown",
           sizeBytes: p.file_size,
-          href: p.pdf_path,
+          href: resolveBackendUrl(p.pdf_path),
           status: p.status,
           abstract: p.abstract,
           // domain: p.team?.domain?.domain_name,
@@ -112,7 +113,7 @@ const TeamDetails = () => {
   const handleDownload = (doc) => {
     if (!doc?.href) return;
     const link = document.createElement("a");
-    link.href = `http://localhost:8000/${doc.href}`;
+    link.href = resolveBackendUrl(doc.href);
     link.download = doc.name || "document.pdf";
     document.body.appendChild(link);
     link.click();
@@ -127,11 +128,11 @@ const TeamDetails = () => {
       const headers = { Authorization: `Bearer ${token}` };
 
       if (type === "proposal") {
-        await axios.delete(`http://localhost:8000/api/proposals/${docId}`, {
+        await axios.delete(resolveApiUrl(`/proposals/${docId}`), {
           headers,
         });
       } else {
-        await axios.delete(`http://localhost:8000/api/papers/${docId}`, {
+        await axios.delete(resolveApiUrl(`/papers/${docId}`), {
           headers,
         });
       }
@@ -149,7 +150,7 @@ const TeamDetails = () => {
       setUpdatingStatus(true);
       const token = localStorage.getItem("token");
       await axios.patch(
-        `http://localhost:8000/api/teacher/teams/${Number(id)}/status`,
+        resolveApiUrl(`/teacher/teams/${Number(id)}/status`),
         { status: next },
         { headers: { Authorization: `Bearer ${token}` } }
       );

--- a/frontend/src/Pages/Teacher/TeamManagement.jsx
+++ b/frontend/src/Pages/Teacher/TeamManagement.jsx
@@ -9,8 +9,9 @@ import {
 import StatCard from "../../components/Common/StatCard";
 import TeamCard from "../../components/Common/TeamCard";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000/api";
+const API_BASE = resolveApiUrl();
 
 const TeamManagement = () => {
   const navigate = useNavigate();

--- a/frontend/src/components/Admin/PaperCard.jsx
+++ b/frontend/src/components/Admin/PaperCard.jsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import { Eye, Bot, PlusCircle } from "lucide-react";
 import PdfViewerModal from "../Common/PdfViewerModal";
-
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8000";
+import { resolveBackendUrl } from "../../config/api";
 
 const PaperCard = ({
   id,
@@ -18,9 +17,7 @@ const PaperCard = ({
 }) => {
   const [openPdf, setOpenPdf] = useState(false);
 
-  const pdfUrl = pdf_path?.startsWith("http")
-    ? pdf_path
-    : `${API_BASE}${pdf_path?.startsWith("/") ? pdf_path : "/" + pdf_path}`;
+  const pdfUrl = pdf_path ? resolveBackendUrl(pdf_path) : null;
 
   const handleViewPdf = () => {
     if (pdf_path) setOpenPdf(true);

--- a/frontend/src/components/Admin/StatusDistributionChart.jsx
+++ b/frontend/src/components/Admin/StatusDistributionChart.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { Doughnut } from "react-chartjs-2";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
@@ -11,7 +12,6 @@ const StatusDistributionChart = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const BASE_URL = "http://localhost:8000/api";
   const token = localStorage.getItem("token");
   const headers = { Authorization: `Bearer ${token}` };
 
@@ -42,7 +42,7 @@ const StatusDistributionChart = () => {
   const fetchStatusDistribution = async () => {
     try {
       setLoading(true);
-      const response = await axios.get(`${BASE_URL}/admin/status-distribution`, {
+      const response = await axios.get(resolveApiUrl('/admin/status-distribution'), {
         headers,
         withCredentials: true,
       });

--- a/frontend/src/components/Admin/SubmissionTrends.jsx
+++ b/frontend/src/components/Admin/SubmissionTrends.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 import axios from 'axios'; // Add this import
+import { resolveApiUrl } from '../../config/api';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
@@ -12,7 +13,6 @@ const SubmissionTrendsChart = () => {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const BASE_URL = "http://localhost:8000/api";
   const token = localStorage.getItem("token");
   const headers = { Authorization: `Bearer ${token}` };
 
@@ -23,7 +23,7 @@ const SubmissionTrendsChart = () => {
   const fetchSubmissionTrends = async () => {
     try {
       setLoading(true);
-      const response = await axios.get(`${BASE_URL}/admin/submission-trends`, {
+      const response = await axios.get(resolveApiUrl('/admin/submission-trends'), {
         headers,
         withCredentials: true
       });

--- a/frontend/src/components/Admin/TeamsPapersCard.jsx
+++ b/frontend/src/components/Admin/TeamsPapersCard.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { FaDownload, FaEye, FaFilePdf, FaFileAlt } from "react-icons/fa";
 import Card from "./Card";
+import { resolveApiUrl } from "../../config/api";
 
 function TeamPapersCard({ title, papers, icon }) {
-  const BASE_URL = "http://localhost:8000";
 
   const handleView = async (paper) => {
     try {
@@ -11,9 +11,9 @@ function TeamPapersCard({ title, papers, icon }) {
       let viewUrl = '';
       
       if (paper.type === 'paper') {
-        viewUrl = `${BASE_URL}/api/papers/${paper.id}/view`;
+        viewUrl = resolveApiUrl(`/papers/${paper.id}/view`);
       } else if (paper.type === 'proposal') {
-        viewUrl = `${BASE_URL}/api/proposals/${paper.id}/view`;
+        viewUrl = resolveApiUrl(`/proposals/${paper.id}/view`);
       } else {
         // Fallback for older data structure
         alert('Unable to determine document type');
@@ -32,9 +32,9 @@ function TeamPapersCard({ title, papers, icon }) {
       let downloadUrl = '';
       
       if (paper.type === 'paper') {
-        downloadUrl = `${BASE_URL}/api/papers/${paper.id}/download`;
+        downloadUrl = resolveApiUrl(`/papers/${paper.id}/download`);
       } else if (paper.type === 'proposal') {
-        downloadUrl = `${BASE_URL}/api/proposals/${paper.id}/download`;
+        downloadUrl = resolveApiUrl(`/proposals/${paper.id}/download`);
       } else {
         alert('Unable to determine document type');
         return;

--- a/frontend/src/components/Common/MemberList.jsx
+++ b/frontend/src/components/Common/MemberList.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { FaUserPlus, FaUserCircle, FaEnvelope, FaTags, FaIdBadge } from "react-icons/fa";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 /** TeamRole: LEAD | RESEARCHER | ASSISTANT */
 const roleToBadgeClasses = (role) => {
@@ -74,13 +75,13 @@ const MemberList = ({ members = [], teamId, canManage = false, onMemberAdded, ti
       const token = localStorage.getItem("token");
 
       // Get creator context to query candidates
-      const ctx = await axios.get("http://localhost:8000/api/me/context", {
+      const ctx = await axios.get(resolveApiUrl("/me/context"), {
         headers: { Authorization: `Bearer ${token}` },
       });
       const { department_id, domains } = ctx.data || {};
       const domainIds = Array.isArray(domains) ? domains.map((d) => d.domain_id) : [];
 
-      const res = await axios.get("http://localhost:8000/api/members", {
+      const res = await axios.get(resolveApiUrl("/members"), {
         params: { departmentId: department_id, domainIds: domainIds.join(",") },
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -119,7 +120,7 @@ const MemberList = ({ members = [], teamId, canManage = false, onMemberAdded, ti
       }));
 
       await axios.post(
-        `http://localhost:8000/api/teacher/teams/${teamId}/add-members`,
+        resolveApiUrl(`/teacher/teams/${teamId}/add-members`),
         { members: payload },
         { headers: { Authorization: `Bearer ${token}` } }
       );

--- a/frontend/src/components/Common/RecentSubmission.jsx
+++ b/frontend/src/components/Common/RecentSubmission.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { FaRegEye } from "react-icons/fa";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const RecentSubmission = ({ scope = "teacher", limit = 3 }) => {
   const [items, setItems] = useState([]); // unified papers+proposals
@@ -8,21 +9,18 @@ const RecentSubmission = ({ scope = "teacher", limit = 3 }) => {
   const [error, setError] = useState(null);
   const didFetch = useRef(false);
 
-  const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000/api";
-  const FILE_BASE = import.meta.env.VITE_FILE_BASE || "http://localhost:8000";
-
   const token = localStorage.getItem("token");
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
   const endpoints =
     scope === "student"
       ? {
-          papers: `${API_BASE}/student/my-teams/papers`,
-          proposals: `${API_BASE}/student/my-teams/proposals`,
+          papers: resolveApiUrl("/student/my-teams/papers"),
+          proposals: resolveApiUrl("/student/my-teams/proposals"),
         }
       : {
-          papers: `${API_BASE}/teacher/my-teams/papers`,
-          proposals: `${API_BASE}/teacher/my-teams/proposals`,
+          papers: resolveApiUrl("/teacher/my-teams/papers"),
+          proposals: resolveApiUrl("/teacher/my-teams/proposals"),
         };
 
   useEffect(() => {
@@ -50,7 +48,11 @@ const RecentSubmission = ({ scope = "teacher", limit = 3 }) => {
             aggregated_decided_at: x.aggregated_decided_at || null,
             type, // 'paper' | 'proposal'
             download_url:
-              x.download_url || (x.pdf_path ? `${FILE_BASE}/${x.pdf_path}` : null),
+              x.download_url
+                ? resolveBackendUrl(x.download_url)
+                : x.pdf_path
+                ? resolveBackendUrl(x.pdf_path)
+                : null,
           }));
 
         const unified = [

--- a/frontend/src/components/Common/ReviewTable.jsx
+++ b/frontend/src/components/Common/ReviewTable.jsx
@@ -1,8 +1,7 @@
 // frontend/src/components/Common/ReviewTable.jsx
 import React from 'react';
 import { Eye, FileText, Download } from 'lucide-react';
-
-const API_BASE_URL = import.meta.env.APP_URL || "http://localhost:8000/api";
+import { resolveBackendUrl } from '../../config/api';
 
 const ReviewTable = ({ data, loading, pagination, onPageChange }) => {
   const handleViewDetails = (reviewId) => {
@@ -13,9 +12,7 @@ const ReviewTable = ({ data, loading, pagination, onPageChange }) => {
 
   const handleDownloadAttachment = (attachmentPath) => {
     if (attachmentPath) {
-      const downloadUrl = attachmentPath.startsWith('http') 
-        ? attachmentPath 
-        : `${API_BASE_URL.replace('/api', '')}${attachmentPath}`;
+      const downloadUrl = resolveBackendUrl(attachmentPath);
       window.open(downloadUrl, '_blank');
     }
   };

--- a/frontend/src/components/Common/Sidebar.jsx
+++ b/frontend/src/components/Common/Sidebar.jsx
@@ -3,8 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { FaTimes, FaBookOpen } from "react-icons/fa";
 import axios from "axios";
 import { useAuth } from "../../context/AuthContext";
-
-const API_BASE = "http://localhost:8000";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const roleLabel = (profile) => {
   const r = profile?.role;
@@ -19,11 +18,7 @@ const roleLabel = (profile) => {
 
 const withTs = (url) => {
   if (!url) return null;
-  let full = url;
-  if (url.startsWith("/images/") || url.startsWith("images/")) {
-    const path = url.startsWith("/") ? url : `/${url}`;
-    full = `${API_BASE}${path}`;
-  }
+  const full = resolveBackendUrl(url);
   const sep = full.includes("?") ? "&" : "?";
   return `${full}${sep}t=${Date.now()}`;
 };
@@ -46,7 +41,7 @@ const Sidebar = ({ role = "teacher", isOpen, onClose, children }) => {
       try {
         const ts = Date.now();
         const { data } = await axios.get(
-          `${API_BASE}/api/user/profile/${userId}?t=${ts}`,
+          resolveApiUrl(`/user/profile/${userId}?t=${ts}`),
           { headers: { Authorization: `Bearer ${token}` } }
         );
         const p = data?.profile || {};

--- a/frontend/src/components/Common/TeamActivity.jsx
+++ b/frontend/src/components/Common/TeamActivity.jsx
@@ -1,6 +1,7 @@
 // components/Teacher/TeamActivity.jsx
 import React, { useEffect, useRef, useState } from "react";
 import axios from "axios";
+import { resolveApiUrl } from "../../config/api";
 
 const TeamActivity = ({ scope = "teacher", limit = 12 }) => {
   const [comments, setComments] = useState([]);
@@ -8,14 +9,13 @@ const TeamActivity = ({ scope = "teacher", limit = 12 }) => {
   const [error, setError] = useState(null);
   const didFetch = useRef(false);
 
-  const BASE = "http://localhost:8000";
   const token = localStorage.getItem("token");
   const headers = { Authorization: `Bearer ${token}` };
 
   const commentsEndpoint =
     scope === "student"
-      ? `${BASE}/api/student/my-teams/comments`
-      : `${BASE}/api/teacher/my-teams/comments`;
+      ? resolveApiUrl("/student/my-teams/comments")
+      : resolveApiUrl("/teacher/my-teams/comments");
 
   useEffect(() => {
     if (didFetch.current) return; // avoid double-fetch in StrictMode

--- a/frontend/src/components/Common/Topbar.jsx
+++ b/frontend/src/components/Common/Topbar.jsx
@@ -4,8 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 import { useEffect, useMemo, useState } from "react";
 import axios from "axios";
-
-const API_BASE = "http://localhost:8000";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 const Topbar = ({ onMenuClick, onLogout }) => {
   const navigate = useNavigate();
@@ -17,16 +16,7 @@ const Topbar = ({ onMenuClick, onLogout }) => {
   // Build a safe, absolute URL and add ?t= cache-buster
   const withTs = (url) => {
     if (!url) return null;
-    let full = url;
-
-    // If BE returned a relative path like "images/xxx.png" or "/images/xxx.png"
-    if (url.startsWith("/images/") || url.startsWith("images/")) {
-      const path = url.startsWith("/") ? url : `/${url}`;
-      full = `${API_BASE}${path}`;
-    }
-
-    // If BE already returned full http://localhost:8000/images/...
-    // we keep it as is and just add the timestamp.
+    const full = resolveBackendUrl(url);
     const sep = full.includes("?") ? "&" : "?";
     return `${full}${sep}t=${Date.now()}`;
   };
@@ -37,7 +27,7 @@ const Topbar = ({ onMenuClick, onLogout }) => {
       try {
         const ts = Date.now(); // also bust cache on the profile response
         const { data } = await axios.get(
-          `${API_BASE}/api/user/profile/${userId}?t=${ts}`,
+          resolveApiUrl(`/user/profile/${userId}?t=${ts}`),
           { headers: { Authorization: `Bearer ${token}` } }
         );
 

--- a/frontend/src/components/Profile/AvatarPicker.jsx
+++ b/frontend/src/components/Profile/AvatarPicker.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 function AvatarPicker({ userId, token, currentUrl, onUpdated }) {
   const [preview, setPreview] = useState(null);
@@ -8,16 +9,7 @@ function AvatarPicker({ userId, token, currentUrl, onUpdated }) {
 
   useEffect(() => {
     if (currentUrl) {
-      let processedUrl = currentUrl;
-
-      if (currentUrl.startsWith("http://localhost:8000/")) {
-        // already absolute
-      } else if (currentUrl.startsWith("/images/") || currentUrl.startsWith("images/")) {
-        const imagePath = currentUrl.startsWith("/") ? currentUrl : `/${currentUrl}`;
-        processedUrl = `http://localhost:8000${imagePath}`;
-      } else {
-        processedUrl = `http://localhost:8000/images/${currentUrl}`;
-      }
+      const processedUrl = resolveBackendUrl(currentUrl);
 
       const t = Date.now();
       const sep = processedUrl.includes("?") ? "&" : "?";
@@ -60,7 +52,7 @@ function AvatarPicker({ userId, token, currentUrl, onUpdated }) {
       formData.append("avatar", file);
 
       const response = await axios.post(
-        `http://localhost:8000/api/user/avatar/${userId}`,
+        resolveApiUrl(`/user/avatar/${userId}`),
         formData,
         {
           headers: {
@@ -111,16 +103,7 @@ function AvatarPicker({ userId, token, currentUrl, onUpdated }) {
     setFile(null);
 
     if (currentUrl) {
-      let processedUrl = currentUrl;
-
-      if (currentUrl.startsWith("http://localhost:8000/")) {
-        processedUrl = currentUrl;
-      } else if (currentUrl.startsWith("/images/") || currentUrl.startsWith("images/")) {
-        const imagePath = currentUrl.startsWith("/") ? currentUrl : `/${currentUrl}`;
-        processedUrl = `http://localhost:8000${imagePath}`;
-      } else {
-        processedUrl = `http://localhost:8000/public/images/${currentUrl}`;
-      }
+      const processedUrl = resolveBackendUrl(currentUrl);
 
       const t = Date.now();
       const sep = processedUrl.includes("?") ? "&" : "?";

--- a/frontend/src/components/Profile/ProfileHeader.jsx
+++ b/frontend/src/components/Profile/ProfileHeader.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { resolveBackendUrl } from '../../config/api';
 
 const ProfileHeader = ({ name, role, department, avatarUrl }) => {
   const [imageUrl, setImageUrl] = useState(null);
@@ -7,16 +8,7 @@ const ProfileHeader = ({ name, role, department, avatarUrl }) => {
   useEffect(() => {
     if (avatarUrl) {
       // Clean the URL and add cache busting
-      let cleanUrl = avatarUrl;
-      
-      // If it's a full URL, use it as is
-      if (avatarUrl.startsWith('http://localhost:8000/')) {
-        cleanUrl = avatarUrl;
-      } else if (avatarUrl.startsWith('/images/') || avatarUrl.startsWith('images/')) {
-        // Convert relative paths to full URLs for proper CORS handling
-        const imagePath = avatarUrl.startsWith('/') ? avatarUrl : `/${avatarUrl}`;
-        cleanUrl = `http://localhost:8000${imagePath}`;
-      }
+      let cleanUrl = resolveBackendUrl(avatarUrl);
       
       // Add cache busting
       const timestamp = Date.now();

--- a/frontend/src/components/Teacher/TeamManagement/Comment.jsx
+++ b/frontend/src/components/Teacher/TeamManagement/Comment.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { FaUserCircle, FaPaperPlane, FaSpinner } from 'react-icons/fa';
 import axios from 'axios';
+import { resolveApiUrl } from '../../../config/api';
 
 const Comments = ({ teamId }) => {
   const [comment, setComment] = useState('');
@@ -20,7 +21,7 @@ const Comments = ({ teamId }) => {
   const fetchCurrentUser = async () => {
     try {
       const token = localStorage.getItem("token");
-      const response = await axios.get("http://localhost:8000/api/profile", {
+      const response = await axios.get(resolveApiUrl("/profile"), {
         headers: { Authorization: `Bearer ${token}` }
       });
       setCurrentUser(response.data.data);
@@ -33,7 +34,7 @@ const Comments = ({ teamId }) => {
     try {
       setLoading(true);
       const token = localStorage.getItem("token");
-      const response = await axios.get(`http://localhost:8000/api/teams/${teamId}/comments`, {
+      const response = await axios.get(resolveApiUrl(`/teams/${teamId}/comments`), {
         headers: { Authorization: `Bearer ${token}` }
       });
       setComments(response.data.data || []);
@@ -52,7 +53,7 @@ const Comments = ({ teamId }) => {
       setPosting(true);
       const token = localStorage.getItem("token");
       
-      const response = await axios.post(`http://localhost:8000/api/teams/${teamId}/comments`, {
+      const response = await axios.post(resolveApiUrl(`/teams/${teamId}/comments`), {
         comment: comment.trim()
       }, {
         headers: { Authorization: `Bearer ${token}` }

--- a/frontend/src/components/Teacher/TeamManagement/DocumentList.jsx
+++ b/frontend/src/components/Teacher/TeamManagement/DocumentList.jsx
@@ -1,6 +1,7 @@
 // src/components/Teacher/TeamManagement/DocumentList.jsx
 import React, { useState } from 'react';
 import { FaFileAlt, FaTrash, FaDownload, FaUpload, FaEye, FaFilePdf } from 'react-icons/fa';
+import { resolveBackendUrl } from '../../../config/api';
 
 const fmt = (bytes) => {
   if (bytes == null) return '';
@@ -36,7 +37,8 @@ const DocumentList = ({
 
   const handleView = (doc) => {
     if (doc.href) {
-      window.open(`http://localhost:8000/${doc.href}`, '_blank');
+      const targetUrl = resolveBackendUrl(doc.href);
+      window.open(targetUrl, '_blank');
     } else {
       alert('Document not available for viewing.');
     }

--- a/frontend/src/components/Teacher/TeamManagement/MemberList.jsx
+++ b/frontend/src/components/Teacher/TeamManagement/MemberList.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { FaUserPlus, FaUserCircle, FaEnvelope, FaTags } from "react-icons/fa";
 import axios from "axios";
+import { resolveApiUrl } from "../../../config/api";
 
 const MemberList = ({
   onAddMany,
@@ -28,7 +29,7 @@ const MemberList = ({
     }
 
     axios
-      .get("http://localhost:8000/api/members", {
+      .get(resolveApiUrl("/members"), {
         params,
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       })

--- a/frontend/src/components/Teacher/TeamManagement/PaperUpload.jsx
+++ b/frontend/src/components/Teacher/TeamManagement/PaperUpload.jsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { FaFilePdf, FaCheckCircle } from "react-icons/fa";
 import UploadDocModal from "../CreateTeam/UploadModal";
 import axios from "axios";
+import { resolveApiUrl } from "../../../config/api";
 
 const PaperUploader = ({ teamId, onUploadSuccess }) => {
   const [modalKind, setModalKind] = useState(null); // 'paper' | 'proposal'
@@ -22,9 +23,9 @@ const PaperUploader = ({ teamId, onUploadSuccess }) => {
         formData.append("proposal", file);
       }
 
-      const endpoint = kind === "paper" 
-        ? "http://localhost:8000/api/papers/upload"
-        : "http://localhost:8000/api/proposals/upload";
+      const endpoint = resolveApiUrl(
+        kind === "paper" ? "/papers/upload" : "/proposals/upload"
+      );
 
       const response = await axios.post(endpoint, formData, {
         headers: {

--- a/frontend/src/components/Teacher/TeamManagement/PendingApplication.jsx
+++ b/frontend/src/components/Teacher/TeamManagement/PendingApplication.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { FaUserCircle, FaCheck, FaTimes, FaEnvelope, FaIdBadge, FaTags } from 'react-icons/fa';
 import axios from 'axios';
+import { resolveApiUrl } from '../../../config/api';
 
 const PendingApplications = ({ teamId, onApplicationProcessed }) => {
   const [applications, setApplications] = useState([]);
@@ -18,7 +19,7 @@ const PendingApplications = ({ teamId, onApplicationProcessed }) => {
     try {
       setLoading(true);
       const token = localStorage.getItem("token");
-      const response = await axios.get(`http://localhost:8000/api/teams/${teamId}/applications`, {
+      const response = await axios.get(resolveApiUrl(`/teams/${teamId}/applications`), {
         headers: { Authorization: `Bearer ${token}` }
       });
       setApplications(response.data.data || []);
@@ -35,7 +36,7 @@ const PendingApplications = ({ teamId, onApplicationProcessed }) => {
       setProcessing(prev => ({ ...prev, [applicationId]: true }));
       const token = localStorage.getItem("token");
       
-      await axios.patch(`http://localhost:8000/api/applications/${applicationId}`, {
+      await axios.patch(resolveApiUrl(`/applications/${applicationId}`), {
         status: action.toUpperCase()
       }, {
         headers: { Authorization: `Bearer ${token}` }

--- a/frontend/src/components/home/AcceptedPaper.jsx
+++ b/frontend/src/components/home/AcceptedPaper.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { resolveApiUrl, resolveBackendUrl } from "../../config/api";
 
 // Abstract Modal Component
 const AbstractModal = ({ isOpen, onClose, paper }) => {
@@ -112,8 +113,10 @@ const AcceptedPaper = ({
           }
         }
 
-        const url = `http://localhost:8000/api/public/accepted-papers${params.toString() ? `?${params.toString()}` : ''}`;
-        console.log('Fetching papers from:', url);
+        const url = resolveApiUrl(
+          `/public/accepted-papers${params.toString() ? `?${params.toString()}` : ""}`
+        );
+        console.log("Fetching papers from:", url);
 
         const response = await fetch(url);
         
@@ -125,7 +128,11 @@ const AcceptedPaper = ({
         console.log('API Response:', data);
         
         if (data.success) {
-          setPapers(data.papers || []);
+          const normalized = (data.papers || []).map((paper) => ({
+            ...paper,
+            pdf_url: paper.pdf_url ? resolveBackendUrl(paper.pdf_url) : null,
+          }));
+          setPapers(normalized);
         } else {
           throw new Error(data.message || 'Failed to fetch papers');
         }
@@ -148,9 +155,10 @@ const AcceptedPaper = ({
   useEffect(() => {
     const fetchFilters = async () => {
       try {
-        console.log('Fetching filters from: http://localhost:8000/api/public/filters');
-        
-        const response = await fetch("http://localhost:8000/api/public/filters");
+        const filtersUrl = resolveApiUrl("/public/filters");
+        console.log("Fetching filters from:", filtersUrl);
+
+        const response = await fetch(filtersUrl);
         
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,64 @@
+const DEFAULT_BACKEND_ORIGIN = "http://localhost:8000";
+
+const envBackendOrigin = [
+  import.meta.env.VITE_API_BASE_URL,
+  import.meta.env.VITE_API_BASE,
+  import.meta.env.VITE_BACKEND_URL,
+  import.meta.env.VITE_API_ORIGIN,
+]
+  .find((value) => typeof value === "string" && value.trim().length > 0);
+
+const sanitizeOrigin = (origin) => {
+  if (!origin) return origin;
+  return origin.replace(/\/$/, "");
+};
+
+export const BACKEND_ORIGIN = sanitizeOrigin(envBackendOrigin) || DEFAULT_BACKEND_ORIGIN;
+export const API_BASE_URL = `${BACKEND_ORIGIN}/api`;
+export const PUBLIC_API_BASE_URL = `${API_BASE_URL}/public`;
+
+const isAbsoluteUrl = (value = "") => /^https?:\/\//i.test(value);
+
+const replaceLocalhostOrigin = (url) => {
+  if (url?.startsWith(DEFAULT_BACKEND_ORIGIN)) {
+    return `${BACKEND_ORIGIN}${url.slice(DEFAULT_BACKEND_ORIGIN.length)}`;
+  }
+  return url;
+};
+
+export const resolveBackendUrl = (path = "") => {
+  if (!path) {
+    return BACKEND_ORIGIN;
+  }
+
+  if (isAbsoluteUrl(path)) {
+    return replaceLocalhostOrigin(path);
+  }
+
+  if (path.startsWith("/")) {
+    return `${BACKEND_ORIGIN}${path}`;
+  }
+
+  return `${BACKEND_ORIGIN}/${path}`;
+};
+
+export const resolveApiUrl = (path = "") => {
+  if (!path) {
+    return API_BASE_URL;
+  }
+
+  if (isAbsoluteUrl(path)) {
+    return replaceLocalhostOrigin(path);
+  }
+
+  if (path.startsWith("/")) {
+    return `${API_BASE_URL}${path}`;
+  }
+
+  return `${API_BASE_URL}/${path}`;
+};
+
+if (typeof window !== "undefined") {
+  window.__CURCMS_BACKEND_ORIGIN__ = BACKEND_ORIGIN;
+  window.__CURCMS_API_BASE_URL__ = API_BASE_URL;
+}


### PR DESCRIPTION
## Summary
- add a shared frontend API configuration helper and update all API calls to use environment-driven URLs instead of localhost
- normalize asset and download URLs, fix admin submissions filters, and ensure public accepted-paper fetches hit the production endpoint
- make backend CORS origin list configurable so hosted frontends such as Render can access the API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c858cb670c832d98773d152d60ffe6