### PR TITLE
Use hash-based routing for SPA deep links

### DIFF
--- a/backend/controllers/AuthController.js
+++ b/backend/controllers/AuthController.js
@@ -288,13 +288,13 @@ class AuthController {
   try {
     const FE = process.env.FRONTEND_URL || "https://curcms-1.onrender.com";
     const token = req.params.token || req.query.token;
-    if (!token) return res.redirect(`${FE}/verify?status=missing_token`);
+    if (!token) return res.redirect(`${FE}/#/verify?status=missing_token`);
 
     let data;
     try {
       data = jwt.verify(token, process.env.JWT_SECRET);
     } catch {
-      return res.redirect(`${FE}/verify?status=invalid_or_expired`);
+      return res.redirect(`${FE}/#/verify?status=invalid_or_expired`);
     }
     // Uniqueness checks
     const emailExists = await prisma.user.findUnique({ where: { email: data.email } });
@@ -343,10 +343,10 @@ class AuthController {
       }
     });
 
-     return res.redirect(`${FE}/login?verified=true&registered=true`);
+    return res.redirect(`${FE}/#/login?verified=true&registered=true`);
   } catch (err) {
     const FE = process.env.FRONTEND_URL || "https://curcms-1.onrender.com";
-    return res.redirect(`${FE}/verify?status=failed`);
+    return res.redirect(`${FE}/#/verify?status=failed`);
   }
 }
 

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -42,7 +42,7 @@ router.post("/auth/login", AuthController.login);
 router.get("/auth/verify/:token", AuthController.verifyEmail);
 router.get("/auth/verify-email", (req, res) => {
   const FE = process.env.FRONTEND_URL || "https://curcms-1.onrender.com";
-  return res.redirect(`${FE}/verify`);
+  return res.redirect(`${FE}/#/verify`);
 });
 router.post("/auth/switch-role", authMiddleware, AuthController.switchRole);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Routes,
   Route,
   Navigate,

--- a/frontend/static.json
+++ b/frontend/static.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- switch the React router to HashRouter so static hosting can resolve deep links without rewrite support
- update auth verification redirects to point at the hash-based login and verify screens after email confirmation

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cc66f4dad0832db0de0183aedfdb7d