### PR TITLE
Fix Express catch-all route for new path-to-regexp behavior

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -151,7 +151,7 @@ import "./jobs/index.js";
 
 const frontendRedirectIgnorePrefixes = ["/api", "/uploads", "/documents", "/images"]; // Paths served by the backend
 
-app.get("*", (req, res, next) => {
+app.get("/:path(*)", (req, res, next) => {
   if (req.method !== "GET") {
     return next();
   }


### PR DESCRIPTION
## Summary
- update the frontend redirect catch-all route to use an explicit wildcard parameter compatible with Express 5/path-to-regexp v8

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cedf408f94832db4ae700ff988ca78